### PR TITLE
Fixed bug diffusionProto -> dptProto

### DIFF
--- a/dpt.lua
+++ b/dpt.lua
@@ -143,12 +143,12 @@ function MessageType:markupBody( messageDetails, parentTreeNode, bodyRange )
 
 		-- Break open into records & then fields
 		for i,record in ipairs(records) do
-			
+
 			local recordRange = bodyRange:range( rangeBase, #record )
-			local recordTree = bodyNode:add( diffusionProto.fields.record, recordRange, record:toRecordString() )
-							
+			local recordTree = bodyNode:add( dptProto.fields.record, recordRange, record:toRecordString() )
+
 			rangeBase = rangeBase + #record + 1 -- +1 for the delimiter
-		end	
+		end
 	end
 end
 


### PR DESCRIPTION
Hello

I found a bug with the dissector. It was marking but not parsing some of the packets as DPT. Wireshark gave the line number and it was easy to see that it was a naming problem.

Matt
