### PR TITLE
Added support for development version

### DIFF
--- a/dpt.display.connection.lua
+++ b/dpt.display.connection.lua
@@ -112,9 +112,9 @@ local function addConnectionResponse( tree , fullRange, pinfo, response )
 			dptProto.fields.sessionId,
 			response.sessionId.range,
 			string.format(
-				"%016X-%016X",
-				response.sessionId.serverIdentity:tonumber(),
-				response.sessionId.clientIdentity:tonumber()
+				"%s-%s",
+				string.upper( response.sessionId.serverIdentity:tohex() ),
+				string.upper( response.sessionId.clientIdentity:tohex() )
 			)
 		)
 	end

--- a/dpt.parse.lua
+++ b/dpt.parse.lua
@@ -297,10 +297,14 @@ local function parseWS5ConnectionResponse( tvb, client )
 
 	-- Parse Session ID
 	result.sessionId = {}
-	result.sessionId.serverIdentity = tvb( 3, 8 ):int64()
-	result.sessionId.clientIdentity = tvb( 11, 8 ):int64()
+	result.sessionId.serverIdentity = tvb( 3, 8 ):uint64()
+	result.sessionId.clientIdentity = tvb( 11, 8 ):uint64()
 	result.sessionId.range = tvb( 3, 16 )
-	client.clientId = string.format( "%016X-%016X", result.sessionId.serverIdentity:tonumber(), result.sessionId.clientIdentity:tonumber() )
+	client.clientId = string.format(
+		"%s-%s",
+		string.upper( result.sessionId.serverIdentity:tohex() ),
+		string.upper( result.sessionId.clientIdentity:tohex() )
+	)
 
 	-- Parse session token
 	result.sessionTokenRange = tvb( 19, 24 )

--- a/dpt.utilities.lua
+++ b/dpt.utilities.lua
@@ -20,8 +20,24 @@ local field_http_response_code = Field.new("http.response.code");
 local field_http_connection = Field.new("http.connection");
 local field_http_upgrade = Field.new("http.upgrade");
 local field_http_uri = Field.new("http.request.uri");
-local field_ws_binary_payload = Field.new("websocket.payload.binary");
-local field_ws_text_payload = Field.new("websocket.payload.text");
+local field_ws_binary_payload
+local field_ws_text_payload
+
+-- Attempt to set the websocket fields to those used by Wireshark 1.12
+local function set_version_112_fields()
+	field_ws_binary_payload = Field.new("websocket.payload.binary")
+	field_ws_text_payload = Field.new("websocket.payload.text")
+end
+
+-- Attempt to set the websocket fields to those used by Wireshark 1.99
+local function set_version_199_fields()
+	field_ws_binary_payload = Field.new("data.data")
+	field_ws_text_payload = Field.new("data-text-lines")
+end
+
+if not pcall(set_version_112_fields) then
+	set_version_199_fields()
+end
 
 -- Get the src host either from IPv4 or IPv6
 local function f_src_host()


### PR DESCRIPTION
Added support for version 1.99 by supporting multiple field names for WS data and fixed issue with bad Session ID handling. The session ID handling is broken in all versions but fails more obviously in 1.99.