### PR TITLE
Byte range URI parsing

### DIFF
--- a/dpt.display.connection.lua
+++ b/dpt.display.connection.lua
@@ -47,6 +47,9 @@ local function addConnectionRequest( tree , fullRange, pinfo, request )
 	if request.topicsetRange ~= nil then
 		messageTree:add( dptProto.fields.loginTopics, request.topicsetRange )
 	end
+	if request.reconnectionTimeout ~= nil then
+		messageTree:add( dptProto.fields.reconnectionTimeout, request.reconnectionTimeout, tonumber( request.reconnectionTimeout:string() ) )
+	end
 
 	if request.sessionTokenRange ~= nil then
 		messageTree:add( dptProto.fields.sessionToken, request.sessionTokenRange )

--- a/dpt.display.connection.lua
+++ b/dpt.display.connection.lua
@@ -21,19 +21,19 @@ local function addConnectionRequest( tree , fullRange, pinfo, request )
 		messageTree:add( dptProto.fields.connectionProtoNumber, request.protoVerRange )
 	end
 	if request.wsProtoVersion ~= nil then
-		messageTree:add( dptProto.fields.wsConnectionProtoNumber, request.wsProtoVersion )
+		messageTree:add( dptProto.fields.connectionProtoNumber, request.wsProtoVersion, tonumber( request.wsProtoVersion:string() ) )
 	end
 	if request.connectionTypeRange ~= nil then
 		messageTree:add( dptProto.fields.connectionType, request.connectionTypeRange )
 	end
 	if request.wsConnectionType ~= nil then
-		messageTree:add( dptProto.fields.wsConnectionType, request.wsConnectionType )
+		messageTree:add( dptProto.fields.wsConnectionType, request.wsConnectionType.range, request.wsConnectionType.string )
 	end
 	if request.capabilitiesRange ~= nil then
 		messageTree:add( dptProto.fields.capabilities, request.capabilitiesRange )
 	end
 	if request.capabilities ~= nil then
-		messageTree:add( dptProto.fields.capabilities, fullRange( 0, 0 ), request.capabilities )
+		messageTree:add( dptProto.fields.capabilities, request.capabilities, tonumber( request.capabilities:string() ) )
 	end
 	if request.creds ~= nil then
 		messageTree:add( dptProto.fields.loginCreds, request.creds.range, request.creds.string )

--- a/dpt.dissector.lua
+++ b/dpt.dissector.lua
@@ -75,7 +75,7 @@ end
 local function tryDissectWSConnection( tvb, pinfo )
 	local uri = f_http_uri()
 	if uri ~= nil then
-		if uri:startsWith("/diffusion") then
+		if uri:string():startsWith("/diffusion") then
 			local tcpStream = f_tcp_stream()
 			return parseWSConnectionRequest( tvb, tcpConnections[tcpStream].client )
 		end

--- a/dpt.parse.lua
+++ b/dpt.parse.lua
@@ -374,7 +374,8 @@ local function parseWSConnectionRequest( tvb, client )
 		},
 		capabilities = parameters["ca"],
 		wsPrincipal = parameters["username"],
-		wsCredentials = parameters["password"]
+		wsCredentials = parameters["password"],
+		reconnectionTimeout = parameters["r"],
 	}
 end
 

--- a/dpt.parse.lua
+++ b/dpt.parse.lua
@@ -311,34 +311,68 @@ local function parseConnectionResponse( tvb, client )
 	end
 end
 
-local function uriToQueryParameters( uri )
+local function uriToQueryParameters( uriRange )
 	local parameterTable = {}
-	local queryString = string.gsub(uri, "/diffusion%?", "")
-	info( queryString )
-	-- Foreach '&' separated string split around '=' and store as key value pairs
-	info( "Parameters" )
-	string.gsub( queryString, "([^&]+)", function( parameterPair )
-		local parameterComponents = parameterPair:split("=")
-		parameterTable[parameterComponents[1]] = parameterComponents[2]
-	end )
-	info ( dump(parameterTable) )
+
+	info( uriRange:len() )
+	-- Check length
+	if (uriRange:len() < 12) then
+		return {}
+	end
+
+	-- Check start
+	local uriPrefix = uriRange( 0, 11 ):string()
+	info( uriPrefix )
+	if uriPrefix ~= "/diffusion?" then
+		return {}
+	end
+
+	local remainingParameters = uriRange( 11 )
+
+	while remainingParameters:len() > 0 do
+		-- Get the parameter name
+		local nameEnd = 0
+		while nameEnd < remainingParameters:len() and remainingParameters( nameEnd, 1 ):string() ~= "=" do
+			nameEnd = nameEnd + 1
+		end
+
+		-- Get the parameter value
+		local valueEnd = nameEnd
+		while valueEnd < remainingParameters:len() and remainingParameters( valueEnd, 1 ):string() ~= "&" do
+			valueEnd = valueEnd + 1
+		end
+
+		local name = remainingParameters( 0, nameEnd )
+		local value = remainingParameters( nameEnd + 1 , valueEnd - nameEnd - 1 )
+
+		parameterTable[name:string()] = value
+
+		if valueEnd == remainingParameters:len() then
+			remainingParameters = remainingParameters( 0, 0 )
+		else
+			remainingParameters = remainingParameters( valueEnd + 1 )
+		end
+	end
 
 	return parameterTable
 end
 
 local function parseWSConnectionRequest( tvb, client )
-	local uri = f_http_uri()
-	local parameters = uriToQueryParameters( uri )
+	local uriRange = f_http_uri()
+	local parameters = uriToQueryParameters( uriRange )
 
-	local clientType = lookupClientTypeByChar( parameters["ty"] )
+	local clientType = lookupClientTypeByChar( parameters["ty"]:string() )
 	client.wsConnectionType = clientType
-	client.capabilities = tonumber( parameters["ca"] )
+	client.capabilities = tonumber( parameters["ca"]:string() )
 
 	return {
 		request = true,
 		wsProtoVersion = parameters["v"],
-		wsConnectionType = clientType,
-		capabilities = tonumber( parameters["ca"] ),
+		wsConnectionType = {
+			range = parameters["ty"],
+			string = clientType
+		},
+		capabilities = parameters["ca"],
 		wsPrincipal = parameters["username"],
 		wsCredentials = parameters["password"]
 	}

--- a/dpt.proto.lua
+++ b/dpt.proto.lua
@@ -224,6 +224,7 @@ dptProto.fields.wsPrincipal = ProtoField.string( "dpt.ws.connection.principal", 
 dptProto.fields.wsCredentials = ProtoField.string( "dpt.ws.connection.credentials", "Credentials")
 dptProto.fields.sessionId = ProtoField.string( "dpt.connection.sessionId", "Session Id")
 dptProto.fields.sessionToken = ProtoField.string( "dpt.connection.sessionToken", "Session Token")
+dptProto.fields.reconnectionTimeout = ProtoField.uint32( "dpt.connection.reconnectionTimeout", "Reconnection timeout", base.DEC )
 dptProto.fields.pingPeriod = ProtoField.uint64( "dpt.connection.pingPeriod", "System ping period", base.DEC )
 
 -- Message fields

--- a/dpt.utilities.lua
+++ b/dpt.utilities.lua
@@ -117,7 +117,7 @@ end
 local function f_http_uri()
 	local f = field_http_uri()
 	if f ~= nil then
-		return f.value
+		return f.range
 	else
 		return nil
 	end


### PR DESCRIPTION
Parse the URI of a WebSocket connection as a byte range instead of a string. This enables Wireshark to associate parsed values with the bytes in the packet.