### PR TITLE
Fix reference to namespace, "constants" -> "const".

### DIFF
--- a/dpt.dissector.lua
+++ b/dpt.dissector.lua
@@ -35,9 +35,9 @@ local messageTypeLookup = diffusion.messages.messageTypeLookup
 
 local dptProto = diffusion.proto.dptProto
 
-local DIFFUSION_MAGIC_NUMBER = diffusion.constants.DIFFUSION_MAGIC_NUMBER
-local TOPIC_VALUE_MESSAGE_TYPE = diffusion.constants.TOPIC_VALUE_MESSAGE_TYPE
-local TOPIC_DELTA_MESSAGE_TYPE = diffusion.constants.TOPIC_DELTA_MESSAGE_TYPE
+local DIFFUSION_MAGIC_NUMBER = diffusion.const.DIFFUSION_MAGIC_NUMBER
+local TOPIC_VALUE_MESSAGE_TYPE = diffusion.const.TOPIC_VALUE_MESSAGE_TYPE
+local TOPIC_DELTA_MESSAGE_TYPE = diffusion.const.TOPIC_DELTA_MESSAGE_TYPE
 
 local parseAsV4ServiceMessage = diffusion.parseService.parseAsV4ServiceMessage
 local parseAsV59ServiceMessage = diffusion.parseService.parseAsV59ServiceMessage

--- a/dpt.parse.common.lua
+++ b/dpt.parse.common.lua
@@ -8,7 +8,7 @@ if master.parseCommon ~= nil then
 	return master.parseCommon
 end
 
-local clientTypesByChar = master.constants.clientTypesByChar
+local clientTypesByChar = master.const.clientTypesByChar
 
 -- Decode the varint used by command serialiser
 -- Takes a range containing the varint


### PR DESCRIPTION
Fixes bug causing "attempt to index field 'constants' (a nil value)" error.
Several times the dissector attempts to access the "constants" namespace, it is actually the "const" namespace it should be using.