### PR TITLE
Message encoding

### DIFF
--- a/dpt.dissector.lua
+++ b/dpt.dissector.lua
@@ -46,6 +46,7 @@ local parseConnectionResponse = diffusion.parse.parseConnectionResponse
 local parseWSConnectionRequest = diffusion.parse.parseWSConnectionRequest
 local parseWSConnectionResponse = diffusion.parse.parseWSConnectionResponse
 local decodeMessageType = diffusion.parse.decodeMessageType
+local decodeMessageEncoding = diffusion.parse.decodeMessageEncoding
 local varint = diffusion.parseCommon.varint
 
 local addClientConnectionInformation = diffusion.displayConnection.addClientConnectionInformation
@@ -252,7 +253,7 @@ local function processWSMessage( tvb, pinfo, tree, descriptions )
 	-- Get the type by
 	local msgTypeRange = tvb( 0, 1 )
 	msgDetails.msgType = decodeMessageType( msgTypeRange:uint() )
-	msgDetails.msgEncoding = 0
+	msgDetails.msgEncoding = decodeMessageEncoding( msgTypeRange:uint() )
 	local messageType = messageTypeLookup(msgDetails.msgType)
 
 	-- Add to the GUI the size-header, type-header & encoding-header
@@ -261,6 +262,7 @@ local function processWSMessage( tvb, pinfo, tree, descriptions )
 
 	messageTree:add( dptProto.fields.sizeHdr, messageRange, msgDetails.msgSize )
 	local typeNode = messageTree:add( dptProto.fields.typeHdr, msgTypeRange, msgDetails.msgType )
+	messageTree:add( dptProto.fields.encodingHdr, msgTypeRange, msgDetails.msgEncoding )
 	local messageTypeName = nameByID( msgDetails.msgType )
 	typeNode:append_text( " = " .. messageTypeName )
 

--- a/dpt.dissector.lua
+++ b/dpt.dissector.lua
@@ -45,6 +45,7 @@ local parseConnectionRequest = diffusion.parse.parseConnectionRequest
 local parseConnectionResponse = diffusion.parse.parseConnectionResponse
 local parseWSConnectionRequest = diffusion.parse.parseWSConnectionRequest
 local parseWSConnectionResponse = diffusion.parse.parseWSConnectionResponse
+local decodeMessageType = diffusion.parse.decodeMessageType
 local varint = diffusion.parseCommon.varint
 
 local addClientConnectionInformation = diffusion.displayConnection.addClientConnectionInformation
@@ -250,7 +251,7 @@ local function processWSMessage( tvb, pinfo, tree, descriptions )
 	msgDetails.msgSize = tvb:len()
 	-- Get the type by
 	local msgTypeRange = tvb( 0, 1 )
-	msgDetails.msgType = msgTypeRange:uint()
+	msgDetails.msgType = decodeMessageType( msgTypeRange:uint() )
 	msgDetails.msgEncoding = 0
 	local messageType = messageTypeLookup(msgDetails.msgType)
 
@@ -259,7 +260,7 @@ local function processWSMessage( tvb, pinfo, tree, descriptions )
 	local messageTree = tree:add( dptProto, messageRange )
 
 	messageTree:add( dptProto.fields.sizeHdr, messageRange, msgDetails.msgSize )
-	local typeNode = messageTree:add( dptProto.fields.typeHdr, msgTypeRange )
+	local typeNode = messageTree:add( dptProto.fields.typeHdr, msgTypeRange, msgDetails.msgType )
 	local messageTypeName = nameByID( msgDetails.msgType )
 	typeNode:append_text( " = " .. messageTypeName )
 

--- a/dpt.extensions.lua
+++ b/dpt.extensions.lua
@@ -3,6 +3,7 @@ local master = diffusion or {}
 if master.extensions ~= nil then
 	return master.extensions
 end
+local RD, FD = master.utilities.RD, master.utilities.FD
 
 -- Mark up non-printing delimiters
 function string:escapeDiff()

--- a/dpt.lua
+++ b/dpt.lua
@@ -5,8 +5,8 @@
 
 -- This assumes that files are in USER_DIR
 -- require looks in wireshark directories.
-dofile( USER_DIR.."dpt.extensions.lua" )
 dofile( USER_DIR.."dpt.utilities.lua" )
+dofile( USER_DIR.."dpt.extensions.lua" )
 dofile( USER_DIR.."dpt.constants.lua" )
 dofile( USER_DIR.."dpt.info.lua" )
 dofile( USER_DIR.."dpt.services.lua" )

--- a/dpt.parse.lua
+++ b/dpt.parse.lua
@@ -434,6 +434,10 @@ local function decodeMessageType( byte )
 	return bit32.band( byte, 0x3f )
 end
 
+local function decodeMessageEncoding( byte )
+	return bit32.rshift( byte, 6 )
+end
+
 -- Package footer
 master.parse = {
 	parseTopicHeader = parseTopicHeader,
@@ -444,7 +448,9 @@ master.parse = {
 	parseConnectionResponse = parseConnectionResponse,
 	parseWSConnectionRequest = parseWSConnectionRequest,
 	parseWSConnectionResponse = parseWSConnectionResponse,
-	decodeMessageType = decodeMessageType
+	decodeMessageType = decodeMessageType,
+	decodeMessageEncoding = decodeMessageEncoding
+
 }
 diffusion = master
 return master.parse

--- a/dpt.parse.lua
+++ b/dpt.parse.lua
@@ -430,6 +430,10 @@ local function parseWSConnectionResponse( tvb, client )
 	end
 end
 
+local function decodeMessageType( byte )
+	return bit32.band( byte, 0x3f )
+end
+
 -- Package footer
 master.parse = {
 	parseTopicHeader = parseTopicHeader,
@@ -439,7 +443,8 @@ master.parse = {
 	parseConnectionRequest = parseConnectionRequest,
 	parseConnectionResponse = parseConnectionResponse,
 	parseWSConnectionRequest = parseWSConnectionRequest,
-	parseWSConnectionResponse = parseWSConnectionResponse
+	parseWSConnectionResponse = parseWSConnectionResponse,
+	decodeMessageType = decodeMessageType
 }
 diffusion = master
 return master.parse


### PR DESCRIPTION
WebSocket messages assumed no content encoding. The content encoding is encoded in the top two bits of the message type byte. This would cause the message type byte to be incorrectly interpreted. The byte is now decoded to the correct message type and encoding type. The encoding type is displayed in the dissector. Also there was an issue marking up the field and record delimiters because the constants were in the wrong scope.